### PR TITLE
Saved mainwindow state and geometry

### DIFF
--- a/src/Settings/settings.cpp
+++ b/src/Settings/settings.cpp
@@ -41,20 +41,27 @@ Settings& Settings::getInstance()
 
 void Settings::saveWindow(const QMainWindow* window)
 {
-    QSettings settings(FILENAME, QSettings::IniFormat);
+/*    QSettings settings(FILENAME, QSettings::IniFormat);
     settings.beginGroup(window->objectName());
     settings.setValue("geometry", window->saveGeometry());
     settings.setValue("state", window->saveState());
-    settings.endGroup();
+    settings.endGroup();*/
+    windowSettings[window->objectName()].geometry = window->saveGeometry();
+    windowSettings[window->objectName()].state = window->saveState();
 }
 
 void Settings::loadWindow(QMainWindow* window)
 {
-    QSettings settings(FILENAME, QSettings::IniFormat);
+/*    QSettings settings(FILENAME, QSettings::IniFormat);
     settings.beginGroup(window->objectName());
     window->restoreGeometry(settings.value("geometry").toByteArray());
     window->restoreState(settings.value("state").toByteArray());
-    settings.endGroup();
+    settings.endGroup();*/
+    QMap<QString,WindowSettings>::const_iterator i = windowSettings.constFind(window->objectName());
+    if( i == windowSettings.constEnd() )
+        return;
+    window->restoreGeometry(i.value().geometry);
+    window->restoreState(i.value().state);
 }
 
 void Settings::load()
@@ -99,6 +106,17 @@ void Settings::load()
         //statusMessage = s.setValue("statusMessage", statusMessage);
     s.endGroup();
 
+    s.beginGroup("WindowSettings");
+    QStringList windows = s.childGroups();
+    foreach(QString windowName, windows)
+    {
+        s.beginGroup(windowName);
+        windowSettings[windowName].geometry = s.value("geometry").toByteArray();
+        windowSettings[windowName].state = s.value("state").toByteArray();
+        s.endGroup();
+    }
+    s.endGroup();
+
     loaded = true;
 }
 
@@ -131,6 +149,15 @@ void Settings::save()
     s.beginGroup("General");
         s.setValue("username", username);
         //s.setValue("statusMessage", statusMessage);
+    s.endGroup();
+
+    s.beginGroup("WindowSettings");
+    foreach(QString key, windowSettings.keys()) {
+        s.beginGroup(key);
+	s.setValue("geometry", windowSettings.value(key).geometry);
+	s.setValue("state", windowSettings.value(key).state);
+	s.endGroup();
+    }
     s.endGroup();
 }
 

--- a/src/Settings/settings.hpp
+++ b/src/Settings/settings.hpp
@@ -18,6 +18,7 @@
 #define SETTINGS_HPP
 
 #include <QMainWindow>
+#include <QMap>
 
 typedef char optKeyCode;
 
@@ -33,8 +34,8 @@ public:
 
     void executeSettingsDialog(QWidget* parent);
 
-    static void saveWindow(const QMainWindow* window);
-    static void loadWindow(QMainWindow* window);
+    void saveWindow(const QMainWindow* window);
+    void loadWindow(QMainWindow* window);
 
     static const QString FILENAME;
 
@@ -76,6 +77,13 @@ public:
 
     bool enableLogging;
     bool encryptLogs;
+
+    struct WindowSettings
+    {
+        QByteArray geometry;
+	QByteArray state;
+    };
+    QMap<QString,WindowSettings> windowSettings;
 
 signals:
     //void dataChanged();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -19,8 +19,6 @@
 
 int main(int argc, char *argv[])
 {
-    QApplication::setOrganizationName("ProjectTOX");
-    QApplication::setApplicationName("TOX-Qt-GUI");
     QApplication a(argc, argv);
     Starter s;
     return a.exec();

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -29,7 +29,6 @@
 #include <QMenuBar>
 #include <QMessageBox>
 #include <QStackedWidget>
-#include <QSettings>
 
 #include <QDebug>
 
@@ -43,6 +42,7 @@ MainWindow::MainWindow(QWidget* parent)
 
     setGeometry((screenWidth - appWidth) / 2, (screenHeight - appHeight) / 2, appWidth, appHeight);
 
+    setObjectName("mainwindow");
     setWindowTitle("developers' test version, not for public use");
     setWindowIcon(QIcon(":/icons/icon64.png"));
 
@@ -128,10 +128,7 @@ MainWindow::MainWindow(QWidget* parent)
 
     setCentralWidget(pages);
 
-
-    QSettings settings;
-    restoreGeometry(settings.value("geometry").toByteArray());
-    restoreState(settings.value("windowState").toByteArray());
+    Settings::getInstance().loadWindow(this);
 }
 
 MainWindow::~MainWindow()
@@ -143,9 +140,7 @@ MainWindow::~MainWindow()
 
 void MainWindow::closeEvent(QCloseEvent *event)
 {
-    QSettings settings;
-    settings.setValue("geometry", saveGeometry());
-    settings.setValue("windowState", saveState());
+    Settings::getInstance().saveWindow(this);
     QMainWindow::closeEvent(event);
 }
 


### PR DESCRIPTION
Set the organization and application name for QSetting.
Using QMainWindow's saveGeometry(), saveState(), restoreGeometry() and restoreState() to keep window state and geometry after closing and reopening the application.
