### PR TITLE
Smiley fix (part 1 from issue #83)

### DIFF
--- a/resources/icons/theme.th
+++ b/resources/icons/theme.th
@@ -6,10 +6,10 @@
 # - multiple textual representations of the same emoticon shall be separated by 
 #   at least one space, i.e ' '. 
 
- Name        =defaultNameTheme
- Author      =author 
+ Name        =TOX Qt GUI Smileys
+ Author      =FatCow 
  Description =description 
- Version     = version    
+ Version     = 1.0    
  Website     =website     
  Icon        =/emoticons/emotion_smile.png        
 

--- a/src/Settings/guisettingspage.hpp
+++ b/src/Settings/guisettingspage.hpp
@@ -18,6 +18,7 @@
 #define GUISETTINGSPAGE_HPP
 
 #include "abstractsettingspage.hpp"
+#include <QDebug>
 
 class QGroupBox;
 class QCheckBox;
@@ -43,7 +44,7 @@ private:
     QGroupBox* buildAnimationGroup();
     QGroupBox* buildSmileypackGroup();
 
-    void searchSmileyPacks();
+    void searchSmileyPacks(bool defaultPackDir);
 
 
     EmojiFontSettingsDialog *emojiSettings;

--- a/src/smileypack.cpp
+++ b/src/smileypack.cpp
@@ -240,28 +240,6 @@ const Smileypack::SmileyList Smileypack::emojiList()
     return tmpList;
 }
 
-const Smileypack::SmileyList Smileypack::defaultList()
-{
-    static const SmileyList tmpList =
-    {
-        {":/icons/emoticons/emotion_smile.png",    {":)", ":-)", ":o)"}},
-        {":/icons/emoticons/emotion_sad.png",      {":(", ":-("}},
-        {":/icons/emoticons/emotion_grin.png",     {":D", ":-D"}},
-        {":/icons/emoticons/emotion_cool.png",     {"8)", "8-)"}},
-        {":/icons/emoticons/emotion_suprised.png", {":O", ":-O"}},
-        {":/icons/emoticons/emotion_wink.png",     {";)", ";-)"}},
-        {":/icons/emoticons/emotion_cry.png",      {";(", ";-("}},
-        {":/icons/emoticons/emotion_sweat.png",    {"(:|"}},
-        {":/icons/emoticons/emotion_kiss.png",     {":*", ":-*"}},
-        {":/icons/emoticons/emotion_tongue.png",   {":P", ":-P"}},
-        {":/icons/emoticons/emotion_doubt.png",    {":^)", ":^-)"}},
-        {":/icons/emoticons/emotion_love.png",     {"(inlove)"}},
-        {":/icons/emoticons/emotion_evilgrin.png", {"]:)", "]:-)"}},
-        {":/icons/emoticons/emotion_angel.png",    {"O:)", "O:-)", "o:)", "o:-)", "(angel)"}}
-    };
-    return tmpList;
-}
-
 bool Smileypack::parseFile(const QString &filePath)
 {
     // Open file
@@ -352,6 +330,12 @@ void Smileypack::processLine(const QString &xLine, const QString &xPath, ParserS
 const QString &Smileypack::packDir()
 {
     static QString path = QStandardPaths::writableLocation(QStandardPaths::ConfigLocation) + '/' + "smileys";
+    return path;
+}
+
+const QString &Smileypack::defaultPackDirRelative()
+{
+    static QString path = QString("../resources") + '/' + "icons";
     return path;
 }
 

--- a/src/smileypack.hpp
+++ b/src/smileypack.hpp
@@ -57,12 +57,13 @@ public:
     void setEmoji(bool x)                           { emoji = x;          }
 
     static const QString& packDir();
+    static const QString& defaultPackDirRelative();
     static QString smilify(QString text);
     static QString desmilify(QString htmlText);
     static QString deemojify(QString text);
     static QString resizeEmoji(QString text);
     static const SmileyList emojiList();
-    static const SmileyList defaultList();
+//    static const SmileyList defaultList();
 
 private:
     QString themeFile;


### PR DESCRIPTION
Fixes first point in issue #83:
- Move the default smiley pack into a resource directory and treat it just as if it was located in a file system, instead of hardcoding the config for the smiley pack in cpp. That would also allow the default slimey pack to be moved out of .exe if needed without any trouble.

Solution:
- /resources/icon/theme.th file has been created. Contains previous default smiley pack info.
- Removed default smiley pack from smileypack.cpp.
- Added extension type .th to identify theme files.
- scans two directories for theme files: ~/.config/ and ../resources/icon/ 
