### PR TITLE
Fix compilation error

### DIFF
--- a/src/editablelabelwidget.hpp
+++ b/src/editablelabelwidget.hpp
@@ -30,7 +30,7 @@ public:
     explicit ClickableCopyableElideLabel(QWidget* parent = 0);
 
 protected:
-    bool event(QEvent* event) override;
+    bool event(QEvent* event);
 
 signals:
     void clicked();


### PR DESCRIPTION
Environment:
- linux 32 bit
- QT 5.2.0
- gcc 4.6.3

On given environment, that piece of code fails building:
g++ -c -pipe -O2 -std=c++0x -Wall -W -D_REENTRANT -fPIE -DQT_NO_DEBUG -DQT_WIDGETS_LIB -DQT_GUI_LIB -DQT_CORE_LIB -I/opt/Qt5.2.0/5.2.0/gcc/mkspecs/linux-g++ -I../projectfiles/QtCreator -I../src -I../submodules/ProjectTox-Core/toxcore -I/opt/Qt5.2.0/5.2.0/gcc/include -I/opt/Qt5.2.0/5.2.0/gcc/include/QtWidgets -I/opt/Qt5.2.0/5.2.0/gcc/include/QtGui -I/opt/Qt5.2.0/5.2.0/gcc/include/QtCore -I. -I. -o main.o ../src/main.cpp
In file included from ../src/ouruseritemwidget.hpp:20:0,
                 from ../src/mainwindow.hpp:22,
                 from ../src/starter.hpp:20,
                 from ../src/main.cpp:17:
../src/editablelabelwidget.hpp:33:29: error: expected ‘;’ at end of member declaration
../src/editablelabelwidget.hpp:33:31: error: ‘override’ does not name a type
make: **\* [main.o] Error 1
