### PR TITLE
toggle from 'Hide' to 'Show' in tray when hiding window with close-event

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -202,7 +202,7 @@ void MainWindow::closeEvent(QCloseEvent *event)
 {
     bool minimize = Settings::getInstance().isMinimizeOnCloseEnabled();
     if (isVisible() && minimize) {
-        hide();
+        onShowHideWindow();
         event->ignore();
     } else {
         Settings::getInstance().saveGeometryState(this);


### PR DESCRIPTION
This is a simple bug fix, otherwise the text in the tray still remains 'Hide'
