### PR TITLE
add missing lib to .pro file

### DIFF
--- a/projectfiles/QtCreator/TOX-Qt-GUI.pro
+++ b/projectfiles/QtCreator/TOX-Qt-GUI.pro
@@ -40,7 +40,7 @@ win32:INCLUDEPATH += ../../libs/include/
 macx:INCLUDEPATH += /usr/local/include/
 
 win32 {
-    LIBS += ../../libs/lib/libtoxav.a ../../libs/lib/libopus.a ../../libs/lib/libvpx.a ../../libs/lib/libtoxcore.a -lws2_32 ../../libs/lib/libsodium.a
+    LIBS += ../../libs/lib/libtoxav.a ../../libs/lib/libopus.a ../../libs/lib/libvpx.a ../../libs/lib/libtoxcore.a -lws2_32 ../../libs/lib/libsodium.a -liphlpapi
 } else {
     macx {
         LIBS += -L/usr/local/lib -ltoxav -ltoxcore -lsodium


### PR DESCRIPTION
I can't build current tox without `-liphlpapi` under windows.
